### PR TITLE
Patch

### DIFF
--- a/conversejs/boshclient.py
+++ b/conversejs/boshclient.py
@@ -50,7 +50,7 @@ class BOSHClient(object):
 
         """
         self.log = logging.getLogger('conversejs.boshclient')
-        self.log.addHandler(logging.NullHandler())
+        self.log.addHandler(NullHandler())
 
         self._connection = None
         self._sid = None


### PR DESCRIPTION
1.  fix: iterfind is not available in python 2.6, use findall instead
2.  fix: gzipped http content is not handled correctly
3.  fix: pep8 comformation
4.  The authenticate process does not conform DIGEST-MD5, see http://wiki.xmpp.org/web/SASLandDIGEST-MD5.

In step 3, another challenge is sent from server rather than a success response.
we should send a blank challenge response in step 4,
and the server send back success in step 5.

See also the codes from xmpp2:
http://pydoc.net/Python/xmpp2/0.4/xmpp2.handler.sasl/
