### PR TITLE
Add support for django 1.7

### DIFF
--- a/conversejs/forms.py
+++ b/conversejs/forms.py
@@ -8,3 +8,4 @@ class XMPPAccountForm(forms.ModelForm):
 
     class Meta:
         model = XMPPAccount
+        exclude = ()

--- a/conversejs/migrations/0001_initial.py
+++ b/conversejs/migrations/0001_initial.py
@@ -1,66 +1,27 @@
 # -*- coding: utf-8 -*-
-import datetime
-from south.db import db
-from south.v2 import SchemaMigration
-from django.db import models
+from __future__ import unicode_literals
 
-try:
-    from django.contrib.auth import get_user_model
-except ImportError: # django < 1.5
-    from django.contrib.auth.models import User
-else:
-    User = get_user_model()
+from django.db import models, migrations
+from django.conf import settings
 
 
-class Migration(SchemaMigration):
+class Migration(migrations.Migration):
 
-    def forwards(self, orm):
-        # Adding model 'XMPPAccount'
-        db.create_table(u'conversejs_xmppaccount', (
-            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm["%s.%s" % (User._meta.app_label, User._meta.object_name)])),
-            ('jid', self.gf('django.db.models.fields.CharField')(max_length=300)),
-            ('password', self.gf('django.db.models.fields.CharField')(max_length=1024)),
-        ))
-        db.send_create_signal(u'conversejs', ['XMPPAccount'])
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
 
-
-    def backwards(self, orm):
-        # Deleting model 'XMPPAccount'
-        db.delete_table(u'conversejs_xmppaccount')
-
-
-    models = {
-        u'auth.group': {
-            'Meta': {'object_name': 'Group'},
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
-            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
-        },
-        u'auth.permission': {
-            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
-            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
-        },
-        "%s.%s" % (User._meta.app_label, User._meta.module_name): {
-            'Meta': {'object_name': User.__name__},
-        },
-        u'contenttypes.contenttype': {
-            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
-            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
-        },
-        u'conversejs.xmppaccount': {
-            'Meta': {'object_name': 'XMPPAccount'},
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'jid': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
-            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['%s.%s']"% (User._meta.app_label, User._meta.object_name)})
-        }
-    }
-
-    complete_apps = ['conversejs']
+    operations = [
+        migrations.CreateModel(
+            name='XMPPAccount',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('jid', models.CharField(max_length=300)),
+                ('password', models.CharField(max_length=1024)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/conversejs/models.py
+++ b/conversejs/models.py
@@ -2,11 +2,11 @@
 from django.db import models
 
 try:
-    from django.contrib.auth import get_user_model
+    from django.conf import settings
 except ImportError:
     from django.contrib.auth.models import User
 else:
-    User = get_user_model()
+    User = settings.AUTH_USER_MODEL
 
 
 class XMPPAccount(models.Model):


### PR DESCRIPTION
Note: Migrations are not in django 1.7 format.
-Change migrations to django 1.7 migrations
-Remove warning in django 1.7

Signed-off-by: Matheus Faria <matheus.sousa.faria@gmail.com
Signed-off-by: Gustavo Jaruga <darksshades@gmail.com>
