### PR TITLE
Add support for django 1.7

### DIFF
--- a/conversejs/forms.py
+++ b/conversejs/forms.py
@@ -8,3 +8,4 @@ class XMPPAccountForm(forms.ModelForm):
 
     class Meta:
         model = XMPPAccount
+        exclude = ()

--- a/conversejs/models.py
+++ b/conversejs/models.py
@@ -2,11 +2,11 @@
 from django.db import models
 
 try:
-    from django.contrib.auth import get_user_model
+    from django.conf import settings
 except ImportError:
     from django.contrib.auth.models import User
 else:
-    User = get_user_model()
+    User = settings.AUTH_USER_MODEL
 
 
 class XMPPAccount(models.Model):


### PR DESCRIPTION
Adds support for django 1.7

Note: Still has deprecated warnings(in migration) to preserve django 1.6 compatibility

Signed-off-by: Matheus Faria matheus.sousa.faria@gmail.com
Singed-off-by: Gustavo Jaruga darksshades@hotmail.com
